### PR TITLE
DM/CLI Error pick up the project ID from the YAML file

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -69,10 +69,10 @@ func showStages(stages [][]deployment.Config) {
 		}
 		log.Printf("------------------------------")
 	case "yaml":
-		output, _ := yaml.Marshal(formatedConfig(stages))
+		output, _ := yaml.Marshal(formattedConfig(stages))
 		log.Println("\n" + string(output))
 	case "json":
-		output, _ := json.MarshalIndent(formatedConfig(stages), "", "    ")
+		output, _ := json.MarshalIndent(formattedConfig(stages), "", "    ")
 		log.Println("\n" + string(output))
 	}
 }
@@ -234,14 +234,14 @@ func setDefaultProjectID() {
 			log.Fatalf("error getting gcloud default project: %v", err)
 		}
 		if len(gcloudDefault) == 0 {
-			log.Fatalf("can't get project id from --project arg, CLOUD_FOUNDATION_PROJECT_ID env variable and gcloud default")
+			log.Print("warning: can't set default project ID from --project arg, CLOUD_FOUNDATION_PROJECT_ID env variable and gcloud default")
 		}
 		deployment.DefaultProjectID = gcloudDefault
 	}
 }
 
 // returns anonymous struct suitable for pretty print of JSON and YAML objects
-func formatedConfig(stages [][]deployment.Config) interface{} {
+func formattedConfig(stages [][]deployment.Config) interface{} {
 	type formattedConfig struct {
 		Project    string
 		Deployment string

--- a/cli/deployment/config_test.go
+++ b/cli/deployment/config_test.go
@@ -104,6 +104,7 @@ func TestYamlReplaceOutRefs(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to parse outputs: %v", err)
 	}
+	DefaultProjectID = "my-project"
 	config := NewConfig(GetTestData("cross-ref", "dependent-with-refs.yaml", t), "/home/test.yaml")
 	outputs := map[string]map[string]interface{}{}
 	outputs["prj1.name1"] = output


### PR DESCRIPTION
Before even looking inside yaml file for project ID, CLI was failing on cmd.setDefaultProjectID()
invocation when not provided ways to set project ID from:
  --project argument,
  default project env variable,
  gcloud default project.
Behaviour after fix: as long default project ID is not mandatory, cft will not fail if project ID will could be found in YAML file.
Fail assert code added to config.GetProject() method.

Small typo fix "formated" -> "formatted" added.

Fixes #332